### PR TITLE
Facebook新UIに対応

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Cut fbclid",
-  "version": "1.2.0.1",
+  "version": "2.0.0.0",
   "description": "シェアされたページのURLからfbclidをカットします。",
   "icons": {
     "16": "icon16.png",
@@ -18,7 +18,8 @@
   },
   "permissions":[
     "activeTab",
-    "https://www.facebook.com/*"
+    "https://www.facebook.com/*",
+    "https://l.facebook.com/*"
   ]
 }
 

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -1,9 +1,25 @@
 // background
 
-const facebookRegexp = /^https\:\/\/www\.facebook\.com\//
+const facebookRegexp = /^https:\/\/www\.facebook\.com\//
+const facebookRedirectionRegexp = /^https:\/\/l\.facebook\.com\/l\.php\?/
 
 chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
     if (changeInfo.status === 'complete' && facebookRegexp.test(tab.url)) {
         chrome.tabs.executeScript(tab.id, { file: "scripts/replaceURL.js" });
+    }
+
+    if (changeInfo.status === 'loading' && tab.url && facebookRedirectionRegexp.test(tab.url)){
+        const searchParams = new URLSearchParams((tab.url.split('?'))[1])
+        if (searchParams.has('u')){
+            const active = tab.active
+            chrome.tabs.remove(tab.id)
+            let redirectUrl = searchParams.get('u')
+            const fbclidRegexp = /(%26|%3F|&|\?)fbclid(%3D|=)[\w-]+/
+            const matchRes = redirectUrl.match(fbclidRegexp)
+            if (matchRes){
+                redirectUrl = redirectUrl.replace(matchRes[0],'')
+            }
+            chrome.tabs.create({ url: redirectUrl , index: tab.index, active: active})
+        }
     }
 });

--- a/scripts/replaceURL.js
+++ b/scripts/replaceURL.js
@@ -6,11 +6,12 @@ const fbclidRegexp2 = /(\&|\?)fbclid=[\w-]+/
 const main = () => {
     const aTags = pickupShareURLs()
     aTags.forEach(element => replaceURL(element))
+
     setTimeout(main,500)
 }
 
 const pickupShareURLs = () => {
-    return document.querySelectorAll('a[href*="fbclid%3D"]')
+    return document.querySelectorAll('a[href*="fbclid%3D"],a[href*="fbclid="]')
 }
 
 const replaceURL = element => {
@@ -26,6 +27,7 @@ const replaceURL = element => {
     }
 
     element.setAttribute('href',replacedHref)
+    element.classList.add('cutFbclid')
 }
 
 main();


### PR DESCRIPTION
DOMの編集を行ってもクリック時にhrefの値が更新されるため、リダイレクタのタブを操作する形に変更